### PR TITLE
Fix eas self auth

### DIFF
--- a/src/zepben/auth/authenticator.py
+++ b/src/zepben/auth/authenticator.py
@@ -30,6 +30,12 @@ class AuthMethod(Enum):
     An enum class that represents the different authentication methods that could be returned from the server's
     ewb/config/auth endpoint.
     """
+    @classmethod
+    def _missing_(cls, value):
+        for member in cls:
+            if member.value == value.upper():
+                return member
+
     NONE = "NONE"
     SELF = "self"
     AUTH0 = "AUTH0"

--- a/src/zepben/auth/authenticator.py
+++ b/src/zepben/auth/authenticator.py
@@ -52,7 +52,7 @@ class ZepbenAuthenticator(object):
     auth_method: AuthMethod
     """ The authentication method used by the server """
 
-    verify_certificate: False
+    verify_certificate: bool = False
     """ Whether to verify the SSL certificate when making requests """
 
     issuer_protocol: str = "https"

--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -11,7 +11,7 @@ from unittest.mock import ANY
 
 import pytest
 
-from zepben.auth.authenticator import ZepbenAuthenticator, AuthException, create_authenticator
+from zepben.auth.authenticator import ZepbenAuthenticator, AuthException, create_authenticator, AuthMethod
 
 TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImZha2VraWQifQ.eyJpc3MiOiJodHRwczovL2lzc3Vlci8iLCJzdWIiOiJmYWtlIiwiYXVkIjoiaHR0cHM6Ly9mYWtlLWF1ZC8iLCJpYXQiOjE1OTE4MzQxNzksImV4cCI6OTU5MTkyMDU3OSwiYXpwIjoid2U5ZDNSME5jTUNWckpDZ2ROSWVmWWx6aHo2VE9SaGciLCJzY29wZSI6IndyaXRlOm5ldHdvcmsgcmVhZDpuZXR3b3JrIHdyaXRlOm1ldHJpY3MgcmVhZDpld2IiLCJndHkiOiJjbGllbnQtY3JlZGVudGlhbHMiLCJwZXJtaXNzaW9ucyI6WyJ3cml0ZTpuZXR3b3JrIiwicmVhZDpuZXR3b3JrIiwid3JpdGU6bWV0cmljcyIsInJlYWQ6ZXdiIl19.ay_YTwRsfcNzVdmQ4EgmuNMMypfZIIc8K9dCCtLqUmUJDtE7NUuKaVAmGDdmW1J-ngm0UsH4k6B5QpPIJnLIROpdDf7aRzdE9hNFuSHR3arpyCzmO2-TiFDZLFXQjHf0Q-BaxGoXLQBupGYuQaG_3flaLPB3hPV0nqPoBTIoJgG8n2w0Uo2tePe_y2Blqco1sK2wElwyMlYc-UuTyFSvwKlpSXYmO4ppVmbAa9lS2ley6lcv2TwXLCk0KfIIH2E5OBvJHevZqYEzFBAeLCnahKoWxexsVvEfZr40Nhc6oPRT5yJfHRBnCrDnO1fE96rqguQpsDG-HWCtd2GkpnAXNg"
 
@@ -20,7 +20,8 @@ mock_auth0_issuer_domain = ''.join(random.choices(string.ascii_lowercase, k=10))
 mock_access_token = ''.join(random.choices(string.ascii_lowercase, k=10))
 mock_refresh_token = ''.join(random.choices(string.ascii_lowercase, k=10))
 mock_issuer_protocol = ''.join(random.choices(string.ascii_lowercase, k=10))
-
+mock_auth_method = random.choice(list(AuthMethod))
+mock_verify_certificate = bool(random.getrandbits(1))
 
 class MockResponse:
     def __init__(self, json_data, status_code, reason="", text=""):
@@ -89,8 +90,14 @@ class TestZepbenAuthenticator:
     @mock.patch('zepben.auth.authenticator.requests.post', side_effect=lambda *args, **kwargs: MockResponse(
         {"access_token": TOKEN, "refresh_token": mock_refresh_token, "token_type": "Bearer"}, 200))
     def test_fetch_token_successful(self, mock_post):
-        authenticator = ZepbenAuthenticator(audience=mock_audience, issuer_domain=mock_auth0_issuer_domain, issuer_protocol=mock_issuer_protocol,
-                                            token_path="/fake/path")
+        authenticator = ZepbenAuthenticator(
+            audience=mock_audience,
+            issuer_domain=mock_auth0_issuer_domain,
+            auth_method=mock_auth_method,
+            verify_certificate=mock_verify_certificate,
+            issuer_protocol=mock_issuer_protocol,
+            token_path="/fake/path"
+        )
 
         mock_post.assert_not_called()  # POST request is not made before get_token() is called
 
@@ -99,13 +106,20 @@ class TestZepbenAuthenticator:
         mock_post.assert_called_once_with(
             f"{mock_issuer_protocol}://{mock_auth0_issuer_domain}/fake/path",
             headers=ANY,
-            data=authenticator.token_request_data
+            data=authenticator.token_request_data,
+            verify=mock_verify_certificate
         )  # Appropriate-looking password grant request was made to the issuer
 
     @mock.patch('zepben.auth.authenticator.requests.post', side_effect=lambda *args, **kwargs: MockResponse(None, 404, "test reason", "test text"))
     def test_fetch_token_throws_exception_on_bad_response(self, mock_post):
-        authenticator = ZepbenAuthenticator(audience=mock_audience, issuer_domain=mock_auth0_issuer_domain, issuer_protocol=mock_issuer_protocol,
-                                            token_path="/fake/path")
+        authenticator = ZepbenAuthenticator(
+            audience=mock_audience,
+            issuer_domain=mock_auth0_issuer_domain,
+            auth_method=mock_auth_method,
+            verify_certificate=mock_verify_certificate,
+            issuer_protocol=mock_issuer_protocol,
+            token_path="/fake/path"
+        )
 
         mock_post.assert_not_called()  # POST request is not made before get_token() is called
 
@@ -115,13 +129,20 @@ class TestZepbenAuthenticator:
         mock_post.assert_called_once_with(
             f"{mock_issuer_protocol}://{mock_auth0_issuer_domain}/fake/path",
             headers=ANY,
-            data=authenticator.token_request_data
+            data=authenticator.token_request_data,
+            verify=mock_verify_certificate
         )
 
     @mock.patch('zepben.auth.authenticator.requests.post', side_effect=lambda *args, **kwargs: MockResponse(None, 200, "test reason", "test text"))
     def test_fetch_token_throws_exception_on_missing_json(self, mock_post):
-        authenticator = ZepbenAuthenticator(audience=mock_audience, issuer_domain=mock_auth0_issuer_domain, issuer_protocol=mock_issuer_protocol,
-                                            token_path="/fake/path")
+        authenticator = ZepbenAuthenticator(
+            audience=mock_audience,
+            issuer_domain=mock_auth0_issuer_domain,
+            auth_method=mock_auth_method,
+            verify_certificate=mock_verify_certificate,
+            issuer_protocol=mock_issuer_protocol,
+            token_path="/fake/path"
+        )
 
         mock_post.assert_not_called()  # POST request is not made before get_token() is called
 
@@ -131,14 +152,21 @@ class TestZepbenAuthenticator:
         mock_post.assert_called_once_with(
             f"{mock_issuer_protocol}://{mock_auth0_issuer_domain}/fake/path",
             headers=ANY,
-            data=authenticator.token_request_data
+            data=authenticator.token_request_data,
+            verify=mock_verify_certificate
         )
 
     @mock.patch('zepben.auth.authenticator.requests.post',
                 side_effect=lambda *args, **kwargs: MockResponse({'error': 'fail', 'error_description': 'test error description'}, 200))
     def test_fetch_token_throws_exception_on_error_response(self, mock_post):
-        authenticator = ZepbenAuthenticator(audience=mock_audience, issuer_domain=mock_auth0_issuer_domain, issuer_protocol=mock_issuer_protocol,
-                                            token_path="/fake/path")
+        authenticator = ZepbenAuthenticator(
+            audience=mock_audience,
+            issuer_domain=mock_auth0_issuer_domain,
+            auth_method=mock_auth_method,
+            verify_certificate=mock_verify_certificate,
+            issuer_protocol=mock_issuer_protocol,
+            token_path="/fake/path"
+        )
 
         mock_post.assert_not_called()  # POST request is not made before get_token() is called
 
@@ -148,14 +176,21 @@ class TestZepbenAuthenticator:
         mock_post.assert_called_once_with(
             f"{mock_issuer_protocol}://{mock_auth0_issuer_domain}/fake/path",
             headers=ANY,
-            data=authenticator.token_request_data
+            data=authenticator.token_request_data,
+            verify=mock_verify_certificate
         )
 
     @mock.patch('zepben.auth.authenticator.requests.post',
                 side_effect=lambda *args, **kwargs: MockResponse({'test': 'fail'}, 200))
     def test_fetch_token_throws_exception_on_missing_access_token(self, mock_post):
-        authenticator = ZepbenAuthenticator(audience=mock_audience, issuer_domain=mock_auth0_issuer_domain, issuer_protocol=mock_issuer_protocol,
-                                            token_path="/fake/path")
+        authenticator = ZepbenAuthenticator(
+            audience=mock_audience,
+            issuer_domain=mock_auth0_issuer_domain,
+            auth_method=mock_auth_method,
+            verify_certificate=mock_verify_certificate,
+            issuer_protocol=mock_issuer_protocol,
+            token_path="/fake/path"
+        )
 
         mock_post.assert_not_called()  # POST request is not made before get_token() is called
 
@@ -165,14 +200,21 @@ class TestZepbenAuthenticator:
         mock_post.assert_called_once_with(
             f"{mock_issuer_protocol}://{mock_auth0_issuer_domain}/fake/path",
             headers=ANY,
-            data=authenticator.token_request_data
+            data=authenticator.token_request_data,
+            verify=mock_verify_certificate
         )
 
     @mock.patch('zepben.auth.authenticator.requests.post', side_effect=lambda *args, **kwargs: MockResponse(
         {"access_token": TOKEN, "refresh_token": mock_refresh_token, "token_type": "Bearer"}, 200))
     def test_fetch_token_successful_using_refresh(self, mock_post):
-        authenticator = ZepbenAuthenticator(audience=mock_audience, issuer_domain=mock_auth0_issuer_domain, issuer_protocol=mock_issuer_protocol,
-                                            token_path="/fake/path")
+        authenticator = ZepbenAuthenticator(
+            audience=mock_audience,
+            issuer_domain=mock_auth0_issuer_domain,
+            auth_method=mock_auth_method,
+            verify_certificate=mock_verify_certificate,
+            issuer_protocol=mock_issuer_protocol,
+            token_path="/fake/path"
+        )
 
         authenticator.refresh_request_data['refresh_token'] = mock_refresh_token
         mock_post.assert_not_called()  # POST request is not made before get_token() is called
@@ -182,5 +224,6 @@ class TestZepbenAuthenticator:
         mock_post.assert_called_once_with(
             f"{mock_issuer_protocol}://{mock_auth0_issuer_domain}/fake/path",
             headers=ANY,
-            data=authenticator.refresh_request_data
+            data=authenticator.refresh_request_data,
+            verify=mock_verify_certificate
         )


### PR DESCRIPTION
A couple of tweaks necessary to get EAS self auth working smoothly:

`AuthMethod` enum is now case-insensitive when deserialising from JSON. Necessary because the values returned from EAS are lowercase. Easier to change this here than change the server, and I don't see a good reason why it should be case-sensitive. Happy to take feedback on this if you disagree.

`auth_method` and `verify_certificate` properties now exist in the `ZepbenAuthenticator` class, and are passed in on its construction when using `create_authenticator`. 

`auth_method` is necessary as the EAS client needs to populate `token_request_data` slightly differently depending on the authentication method, so it needs to be able to ask the authenticator what auth method it is using.

`verify_certificate` is necessary because when EAS is configured to use self auth, the resource server and the authentication server are one and the same. If the user has elected to switch off tls cert verification for the resource server, it should also be switched off for the authentication server because they are literally the same server. Otherwise requests will fail at this step.