### PR TITLE
Allow using refresh token to be configured at and after initialisation

### DIFF
--- a/src/zepben/auth/authenticator.py
+++ b/src/zepben/auth/authenticator.py
@@ -71,17 +71,12 @@ class ZepbenAuthenticator(object):
     refresh_request_data = {}
     """ Data to pass in refresh token requests. """
 
-    use_refresh: bool = False
-    """ Whether to use refresh tokens. Will be true if `refresh_request_data` is provided """
-
     _access_token = None
     _refresh_token = None
     _token_expiry = datetime.min
     _token_type = None
 
     def __init__(self):
-        if self.refresh_request_data:
-            self.use_refresh = bool(self.refresh_request_data)
         self.token_request_data["audience"] = self.audience
         self.refresh_request_data["audience"] = self.audience
 
@@ -94,7 +89,7 @@ class ZepbenAuthenticator(object):
             # Stored token has expired, try to refresh
             self._access_token = None
             if self._refresh_token:
-                self._fetch_token_auth0()
+                self._fetch_token_auth0(True)
 
             if self._access_token is None:
                 # If using the refresh token did not work for any reason, self._access_token will still be None.
@@ -109,11 +104,11 @@ class ZepbenAuthenticator(object):
 
         return f"{self._token_type} {self._access_token}"
 
-    def _fetch_token_auth0(self):
+    def _fetch_token_auth0(self, use_refresh: bool = False):
         response = requests.post(
             construct_url(self.issuer_protocol, self.issuer_domain, self.token_path),
             headers={"content-type": "application/x-www-form-urlencoded"},
-            data=self.refresh_request_data if self.use_refresh else self.token_request_data,
+            data=self.refresh_request_data if use_refresh else self.token_request_data,
             verify=self.verify_certificate
         )
 
@@ -131,9 +126,7 @@ class ZepbenAuthenticator(object):
         self._token_type = data["token_type"]
         self._access_token = data["access_token"]
         self._token_expiry = datetime.fromtimestamp(jwt.decode(self._access_token, algorithms=[self.algorithm], options={"verify_signature": False})['exp'])
-
-        if self.use_refresh:
-            self._refresh_token = data["refresh_token"]
+        self._refresh_token = data.get("refresh_token", None)
 
 
 def create_authenticator(conf_address: str, verify_certificate: bool = True, auth_type_field: str = 'authType',

--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -213,12 +213,12 @@ class TestZepbenAuthenticator:
             auth_method=mock_auth_method,
             verify_certificate=mock_verify_certificate,
             issuer_protocol=mock_issuer_protocol,
-            token_path="/fake/path"
+            token_path="/fake/path",
+            use_refresh=True
         )
 
         authenticator.refresh_request_data['refresh_token'] = mock_refresh_token
         mock_post.assert_not_called()  # POST request is not made before get_token() is called
-        authenticator._refresh_token = mock_refresh_token
         assert f"Bearer {TOKEN}" == authenticator.fetch_token()
 
         mock_post.assert_called_once_with(

--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -213,12 +213,12 @@ class TestZepbenAuthenticator:
             auth_method=mock_auth_method,
             verify_certificate=mock_verify_certificate,
             issuer_protocol=mock_issuer_protocol,
-            token_path="/fake/path",
-            use_refresh=True
+            token_path="/fake/path"
         )
 
         authenticator.refresh_request_data['refresh_token'] = mock_refresh_token
         mock_post.assert_not_called()  # POST request is not made before get_token() is called
+        authenticator._refresh_token = mock_refresh_token
         assert f"Bearer {TOKEN}" == authenticator.fetch_token()
 
         mock_post.assert_called_once_with(


### PR DESCRIPTION
FYI @ramonbouckaert - marcus found this bug, _refresh_token was never able to be set, so we were never using refresh tokens.