### PR TITLE
Fix create token fetcher

### DIFF
--- a/src/zepben/auth/client/token_fetcher.py
+++ b/src/zepben/auth/client/token_fetcher.py
@@ -7,7 +7,6 @@ import warnings
 from datetime import datetime
 from enum import Enum
 from typing import Optional
-import logging
 import jwt
 import requests
 from dataclassy import dataclass
@@ -20,8 +19,6 @@ __all__ = ["ZepbenTokenFetcher", "AuthMethod", "AuthException", "create_token_fe
 
 _AUTH_HEADER_KEY = 'authorization'
 
-
-logger = logging.getLogger()
 
 class AuthException(Exception):
     pass

--- a/src/zepben/auth/client/token_fetcher.py
+++ b/src/zepben/auth/client/token_fetcher.py
@@ -153,8 +153,8 @@ def create_token_fetcher(conf_address: str, verify_certificates: bool = True, au
             response = requests.get(conf_address, verify=verify_certificates and (conf_ca_filename or True))
         except Exception as e:
             warnings.warn(str(e))
-            warnings.warn("If RemoteDisconnected, check if eas_https in config is set to the same as the target EAS server. This process may hang indefinetly.")
-            raise ConnectionError("Check if eas_https in config is set to the same as the target EAS server")
+            warnings.warn("If RemoteDisconnected, this process may hang indefinetly.")
+            raise ConnectionError("Are you trying to connect to a HTTPS server with HTTP?")
         if response.ok:
             try:
                 auth_config_json = response.json()

--- a/src/zepben/auth/client/token_fetcher.py
+++ b/src/zepben/auth/client/token_fetcher.py
@@ -157,11 +157,11 @@ def create_token_fetcher(conf_address: str, verify_certificates: bool = True, au
                 auth_method = AuthMethod(auth_config_json[auth_type_field])
                 if auth_method is not AuthMethod.NONE:
                     return ZepbenTokenFetcher(
-                        auth_config_json[audience_field],
-                        auth_config_json[issuer_domain_field],
-                        auth_method,
-                        verify_certificates,
-                        auth_ca_filename
+                        audience=auth_config_json[audience_field],
+                        issuer_domain=auth_config_json[issuer_domain_field],
+                        auth_method=auth_method,
+                        verify_certificate=verify_certificates,
+                        ca_filename=auth_ca_filename
                     )
             except ValueError as e:
                 raise ValueError(f"Expected JSON response from {conf_address}, but got: {response.text}.", e)


### PR DESCRIPTION
If we try to use http protocol to connect to an EAS client with https protocol, the connection will hang with no error.
This change introduce a warning to tell the user what is going on and perhaps they need to change their config.conf.