### PR TITLE
[EWB-4471] Fixing test failure due to incorrect function parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 * None.
 
 ### Fixes
-* Test fixes.
+* Fixed `_get_token_response_from_identity` function parameters so that callers pass correct values.
 
 ### Notes
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 * None.
 
 ### Fixes
-* None.
+* Test fixes.
 
 ### Notes
 * None.

--- a/src/zepben/auth/client/zepben_token_fetcher.py
+++ b/src/zepben/auth/client/zepben_token_fetcher.py
@@ -20,7 +20,7 @@ __all__ = ["ZepbenTokenFetcher", "create_token_fetcher", "get_token_fetcher", "c
 
 
 def _fetch_token_generator(is_entraid: bool, use_identity: bool, identity_url: Optional[str] = None) -> Callable[
-    [Dict, Dict, str, str, str, bool, bool], requests.Response]:
+    [Dict, Dict, str, bool, bool], requests.Response]:
     def post(
         refresh_request_data: Dict,
         token_request_data: Dict,
@@ -57,8 +57,7 @@ def _fetch_token_generator(is_entraid: bool, use_identity: bool, identity_url: O
             verify
         )
 
-    def _get_token_response_from_identity(refresh_request_data: Dict, token_request_data: Dict, issuer_protocol: str, issuer_domain: str, token_path: str,
-                                          refresh: bool = False, verify: bool = False) -> requests.Response:
+    def _get_token_response_from_identity(refresh_request_data: Dict, token_request_data: Dict, token_endpoint: str, refresh: bool = False, verify: bool = False) -> requests.Response:
         return requests.get(identity_url, headers={"Metadata": "true"}, verify=verify)
 
     if use_identity:


### PR DESCRIPTION
# Description

Due to incorrect function parameters the `validate` parameter ends up being always set to False, hence failing the random test if the test passes "True".

# Test Steps

Run `test_fetch_token_managed_identity_successful` test locally a few times in debugger, make sure it's passing with validate set to both "True" and "False".

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~